### PR TITLE
過濾DiscussTitle特殊字元

### DIFF
--- a/discuss.php
+++ b/discuss.php
@@ -374,6 +374,7 @@ function show_one_tad_discuss($DefDiscussID = '')
             $first = $DiscussContent;
         }
 
+        $discuss['DiscussTitle'] = $myts->htmlSpecialChars($discuss['DiscussTitle']);
         $discuss['DiscussTitle'] = str_replace('[s', "<img src='" . XOOPS_URL . '/modules/tad_discuss/images/smiles/s', $discuss['DiscussTitle']);
         $discuss['DiscussTitle'] = str_replace('.gif]', ".gif' hspace=2 align='absmiddle'>", $discuss['DiscussTitle']);
 

--- a/function.php
+++ b/function.php
@@ -205,6 +205,7 @@ function saveItem_Permissions($groups, $itemid, $perm_name)
 function list_tad_discuss($DefBoardID = null)
 {
     global $xoopsDB, $xoopsModule, $xoopsUser, $xoopsModuleConfig, $isAdmin, $xoopsTpl;
+    $myts = \MyTextSanitizer::getInstance();
     $now_uid = is_object($xoopsUser) ? $xoopsUser->uid() : '0';
 
     //取得本模組編號
@@ -284,6 +285,7 @@ function list_tad_discuss($DefBoardID = null)
         $isPublic = isPublic($onlyTo, $uid, $DefBoardID);
         $onlyToName = getOnlyToName($onlyTo);
 
+        $DiscussTitle = $myts->htmlSpecialChars($DiscussTitle);
         $DiscussTitle = str_replace('[s', "<img src='" . XOOPS_URL . '/modules/tad_discuss/images/smiles/s', $DiscussTitle);
         $DiscussTitle = str_replace('.gif]', ".gif' hspace=2 align='absmiddle'>", $DiscussTitle);
 
@@ -532,7 +534,7 @@ function insert_tad_discuss($nl2br = false)
     $ReDiscussID = isset($_POST['ReDiscussID']) ? (int) $_POST['ReDiscussID'] : 0;
     //$now=date('Y-m-d H:i:s',xoops_getUserTimestamp(time()));
     $Discuss = get_tad_discuss($ReDiscussID);
-    $DiscussTitle = empty($_POST['DiscussTitle']) ? 'RE:' . $Discuss['DiscussTitle'] : $_POST['DiscussTitle'];
+    $DiscussTitle = empty($_POST['DiscussTitle']) ? 'RE:' . $Discuss['DiscussTitle'] : $myts->addSlashes($_POST['DiscussTitle']);
     $DiscussTitle = $myts->addSlashes($DiscussTitle);
     $publisher = $myts->addSlashes($_POST['publisher']);
     $BoardID = (int) $_POST['BoardID'];
@@ -583,7 +585,7 @@ function insert_tad_discuss($nl2br = false)
     }
 
     //全局
-    $extra_tags['DISCUSS_TITLE'] = $_POST['DiscussTitle'];
+    $extra_tags['DISCUSS_TITLE'] = $myts->htmlSpecialChars($_POST['DiscussTitle']);
     $extra_tags['DISCUSS_CONTENT'] = strip_tags($_POST['DiscussContent']);
     $extra_tags['DISCUSS_URL'] = XOOPS_URL . "/modules/tad_discuss/discuss.php?DiscussID={$ToDiscussID}&BoardID={$_POST['BoardID']}";
 
@@ -593,7 +595,7 @@ function insert_tad_discuss($nl2br = false)
     //分類
     if (!empty($_POST['BoardID'])) {
         $Board = get_tad_discuss_board($_POST['BoardID']);
-        $extra_tags['BOARD_TITLE'] = $Board['BoardTitle'];
+        $extra_tags['BOARD_TITLE'] = $myts->htmlSpecialChars($Board['BoardTitle']);
         $notificationHandler = xoops_getHandler('notification');
         $notificationHandler->triggerEvent('board', $_POST['BoardID'], 'new_board_discuss', $extra_tags, null, null, 0);
     }

--- a/index.php
+++ b/index.php
@@ -94,6 +94,8 @@ function list_tad_discuss_short($BoardID = null, $limit = null)
 {
     global $xoopsDB, $xoopsModule, $xoopsUser, $xoopsTpl;
 
+    $myts = \MyTextSanitizer::getInstance();
+
     $andBoardID = (empty($BoardID)) ? '' : "and a.BoardID='$BoardID'";
     $andLimit = null !== $limit ? "limit 0,$limit" : '';
     $sql = 'select a.*,b.* from ' . $xoopsDB->prefix('tad_discuss') . ' as a left join ' . $xoopsDB->prefix('tad_discuss_board') . " as b on a.BoardID = b.BoardID where a.ReDiscussID='0' $andBoardID  order by a.LastTime desc $andLimit";
@@ -116,7 +118,7 @@ function list_tad_discuss_short($BoardID = null, $limit = null)
 
         $isPublic = isPublic($onlyTo, $uid, $BoardID);
         $onlyToName = getOnlyToName($onlyTo);
-        $DiscussTitle = $isPublic ? $DiscussTitle : sprintf(_MD_TADDISCUS_ONLYTO, $onlyToName);
+        $DiscussTitle = $isPublic ? $myts->htmlSpecialChars($DiscussTitle) : sprintf(_MD_TADDISCUS_ONLYTO, $onlyToName);
 
         $DiscussTitle = str_replace('[s', "<img src='" . XOOPS_URL . '/modules/tad_discuss/images/smiles/s', $DiscussTitle);
         $DiscussTitle = str_replace('.gif]', ".gif' hspace=2 align='absmiddle'>", $DiscussTitle);


### PR DESCRIPTION
1.過濾DiscussTitle特殊字元
2.DiscussContent若允許使用HTML，則無法避免使用onclick, onload, onerror，可能造成XSS漏洞（目前無解？）